### PR TITLE
removendo o botão voltar do appBar da consulta de estoque

### DIFF
--- a/lib/screens/TelaEstoque.dart
+++ b/lib/screens/TelaEstoque.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:tcc_2/model/EstoqueProduto.dart';
+import 'package:tcc_2/screens/TelaFiltroEstoque.dart';
 
 class TelaEstoque extends StatefulWidget {
   @override
@@ -22,29 +23,29 @@ class _TelaEstoqueState extends State<TelaEstoque> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         title: Text("Consulta de Estoque"),
-            centerTitle: true,
+        centerTitle: true,
       ),
       //Botão para retornar a tela de filtro
-            floatingActionButton: FloatingActionButton(
-            child: Icon(Icons.filter_list),
-            backgroundColor: Theme.of(context).primaryColor,
-            onPressed: () {
-                Navigator.of(context).pop();                
-              }),
+      floatingActionButton: FloatingActionButton(
+          child: Icon(Icons.filter_list),
+          backgroundColor: Theme.of(context).primaryColor,
+          onPressed: () {
+            estoques.clear();
+            Navigator.of(context).pop(estoques);
+            
+          }),
       body: ListView.builder(
-        itemCount: estoques == null ? 0 : estoques.length,
-        itemBuilder: ((context, index){
-
-          return _construirListaEstoque(estoques, index);
-
-        })
-         ),
+          itemCount: estoques == null ? 0 : estoques.length,
+          itemBuilder: ((context, index) {
+            return _construirListaEstoque(estoques, index);
+          })),
     );
   }
 
 //Coloca em cards todos os lotes de produtos com as informações de cada lote
-  Widget _construirListaEstoque(estoques, index){
+  Widget _construirListaEstoque(estoques, index) {
     EstoqueProduto e = estoques[index];
     return InkWell(
       //InkWell eh pra dar uma animacao quando clicar no produto
@@ -53,59 +54,57 @@ class _TelaEstoqueState extends State<TelaEstoque> {
           children: <Widget>[
             //Flexible eh para quebrar a linha caso a descricao do produto seja maior que a largura da tela
             Flexible(
-              //padding: EdgeInsets.all(8.0),
+                //padding: EdgeInsets.all(8.0),
                 child: Padding(
-                  padding: EdgeInsets.all(10.0),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        "Lote: ${e.id}",
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Color.fromARGB(255, 0, 120, 189),
-                            fontSize: 20.0),
-                      ),
-                      Text(
-                        "Qtde: ${e.quantidade.toString()}",
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Colors.black,
-                            fontSize: 17.0),
-                      ),
-                      Text(
-                        "Dt Aquisição: ${_formatarData(e)}",
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Colors.black,
-                            fontSize: 17.0),
-                      ),
-                      Text(
-                        "Preço Compra: ${e.precoCompra.toString()}",
-                        style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Colors.black,
-                            fontSize: 17.0),
-                      ),
-                    ],
+              padding: EdgeInsets.all(10.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Text(
+                    "Lote: ${e.id}",
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Color.fromARGB(255, 0, 120, 189),
+                        fontSize: 20.0),
                   ),
-                ))
+                  Text(
+                    "Qtde: ${e.quantidade.toString()}",
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                        fontSize: 17.0),
+                  ),
+                  Text(
+                    "Dt Aquisição: ${_formatarData(e)}",
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                        fontSize: 17.0),
+                  ),
+                  Text(
+                    "Preço Compra: ${e.precoCompra.toString()}",
+                    style: TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: Colors.black,
+                        fontSize: 17.0),
+                  ),
+                ],
+              ),
+            ))
           ],
         ),
       ),
-      onTap: (){
-        
-      },
+      onTap: () {},
     );
   }
 
-  String _formatarData(EstoqueProduto e){
+  String _formatarData(EstoqueProduto e) {
     return (e.dataAquisicao.day.toString() +
-          "/" +
-          e.dataAquisicao.month.toString() +
-          "/" +
-          e.dataAquisicao.year.toString() +
-          " " +
-          (new DateFormat.Hms().format(e.dataAquisicao)));
+        "/" +
+        e.dataAquisicao.month.toString() +
+        "/" +
+        e.dataAquisicao.year.toString() +
+        " " +
+        (new DateFormat.Hms().format(e.dataAquisicao)));
   }
 }

--- a/lib/screens/TelaFiltroEstoque.dart
+++ b/lib/screens/TelaFiltroEstoque.dart
@@ -7,8 +7,9 @@ import 'package:tcc_2/model/Produto.dart';
 import 'package:tcc_2/screens/TelaEstoque.dart';
 
 class TelaFiltroEstoque extends StatefulWidget {
+  final List<EstoqueProduto> estoques = List();
   @override
-  _TelaFiltroEstoqueState createState() => _TelaFiltroEstoqueState();
+  _TelaFiltroEstoqueState createState() => _TelaFiltroEstoqueState(this.estoques);
 }
 
 class _TelaFiltroEstoqueState extends State<TelaFiltroEstoque> {
@@ -16,13 +17,13 @@ class _TelaFiltroEstoqueState extends State<TelaFiltroEstoque> {
   ProdutoController _controllerProduto = ProdutoController();
   Produto p = Produto();
   List<EstoqueProduto> estoques;
-  Stream<QuerySnapshot> _produtos;
   String _dropdownValueProduto;
+
+  _TelaFiltroEstoqueState(this.estoques);
 
   @override
   void initState() {
     super.initState();
-    _produtos = Firestore.instance.collection("produtos").snapshots();
   }
 
   @override
@@ -55,7 +56,7 @@ class _TelaFiltroEstoqueState extends State<TelaFiltroEstoque> {
 
   Widget _criarDropDownProduto() {
     return StreamBuilder<QuerySnapshot>(
-        stream: _produtos,
+        stream: Firestore.instance.collection("produtos").snapshots(),
         builder: (context, snapshot) {
 
           if (!snapshot.hasData)


### PR DESCRIPTION
removendo o botão voltar do appBar da consulta de estoque pra evitar apresentar registros que não deveriam na consulta já que quando clica naquele botão voltar não consigo limpar o histórico do produto selecionado antes